### PR TITLE
notion: async fetch boards

### DIFF
--- a/notion-data/src/fetch-boards.ts
+++ b/notion-data/src/fetch-boards.ts
@@ -6,9 +6,29 @@ dotenv.config()
 
 const QUEENS_DB_ID = '13c413f810be8070b6aedc3d1e0bb330'
 
+const notion = new Client({
+    auth: process.env.NOTION_TOKEN,
+})
 interface Board {
     date: string
     grid: Array<number>
+}
+
+async function fetchBoardFromNotionPage(pageId: string): Promise<Board> {
+    const response2: any = await notion.pages.retrieve({
+        page_id: pageId,
+    })
+    if (!response2.properties) {
+        return { date: '', grid: [] }
+    }
+    const date = response2.properties.Date?.date?.start
+    const colorArrayVal = response2.properties['Color Array']?.rich_text
+    if (date && colorArrayVal.length > 0) {
+        const boardStr = colorArrayVal[0].plain_text
+        return { date, grid: JSON.parse(boardStr) }
+    }
+
+    return { date: '', grid: [] }
 }
 
 async function main2() {
@@ -29,21 +49,15 @@ async function main2() {
     const pages = response.results.map((object) => object.id)
 
     const outputFile = '../brianl.am/src/board-data.json'
-    const dateToBoard: Array<Board> = [] // : Map<string, Array<number>> = new Map()
-    for (let i = 0; i < pages.length; i++) {
-        const pageId = pages[i]
-        const response2: any = await notion.pages.retrieve({
-            page_id: pageId,
-        })
-        const date = response2.properties.Date?.date?.start
-        const colorArrayVal = response2.properties['Color Array']?.rich_text
-        if (date && colorArrayVal.length > 0) {
-            const boardStr = colorArrayVal[0].plain_text
-            dateToBoard.push({ date, grid: JSON.parse(boardStr) })
-        }
-    }
+    console.log(`Fetching ${pages.length} pages`)
+    await Promise.all(
+        pages.map((pageId) => fetchBoardFromNotionPage(pageId))
+    ).then((boards: Array<{ date: string; grid?: Array<number> }>) => {
+        const validBoards = boards.filter((board) => board['date'] !== '')
+        console.log(validBoards)
+        fs.writeFileSync(outputFile, JSON.stringify(validBoards))
+    })
 
-    fs.writeFileSync(outputFile, JSON.stringify(dateToBoard))
     console.log('Done.')
 }
 


### PR DESCRIPTION
before: fetching each page and board in sequence
now: kick off all fetches and then combine